### PR TITLE
docs: update yield protocol whitepaper url

### DIFF
--- a/protocol/overview/protocol.mdx
+++ b/protocol/overview/protocol.mdx
@@ -9,7 +9,7 @@ import LinkPreview from "../../src/components/LinkPreview";
 # Protocol Overview
 
 Hifi is a fixed-rate, fixed-term lending protocol based on the [The Yield
-Protocol](https://research.paradigm.xyz/Yield.pdf) paper. The protocol is implemented in a system
+Protocol](https://yieldprotocol.com/Yield.pdf) paper. The protocol is implemented in a system
 of Ethereum smart contracts.
 
 ![Hifi Diagram](/img/overview/diagram.png)


### PR DESCRIPTION
The current URL doesn't seem to exist anymore.
Implement the URL to the official Yield Protocol website for their whitepaper.